### PR TITLE
Improve behavior of FIRTOOL_PATH in firtool-resolver

### DIFF
--- a/firtool-resolver/test/firtool_path.sh
+++ b/firtool-resolver/test/firtool_path.sh
@@ -25,3 +25,19 @@ cs launch --scala 2.13.11 \
 # CHECK-NOT: Checking resources for firtool
 $FIRTOOL --version
 # CHECK: CIRCT firtool-[[FIRTOOL_VERSION]]
+
+# We need to also check that if FIRTOOL_PATH is set, we return failure if something goes wrong
+# rather than just going ahead and fetching the dfeault version
+mv $FIRTOOL_BIN ${FIRTOOL_BIN}_renamed
+
+cs launch --scala 2.13.11 \
+  org.chipsalliance::firtool-resolver:$FIRTOOL_RESOLVER_VERSION \
+  --main firtoolresolver.Main \
+  -- \
+  -v \
+  $LLVM_FIRTOOL_VERSION
+# CHECK: Checking FIRTOOL_PATH for firtool
+# CHECK: Running: {{.+}}bin{{.}}firtool --version
+# CHECK: Cannot run program {{.+}}firtool
+# CHECK-NOT: FIRTOOL_PATH not set
+# CHECK-NOT: Checking resources for firtool


### PR DESCRIPTION
1. If FIRTOOL_PATH is set, the --version regex failing no longer will
   return fail, instead it will set version to `<unknown>`.
2. If FIRTOOL_PATH is set and something fails (firtool not found or
   cannot execute the binary), then the error will be returned rather
   than firtool-resolver falling back to fetching the default version.
3. Errors from running firtool will be logged and returned rather than
   unconditionally turned into "Firtool binary not on FIRTOOL_PATH".