### PR TITLE
Bump firtool-resolver dependencies

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -242,8 +242,8 @@ object `firtool-resolver` extends ScalaModule with ChipsAlliancePublishModule {
 
   def ivyDeps = Agg(
     ivy"dev.dirs:directories:26",
-    ivy"com.lihaoyi::os-lib:0.9.1",
-    ivy"com.outr::scribe:3.11.5",
-    ivy"io.get-coursier::coursier:2.1.5",
+    ivy"com.lihaoyi::os-lib:0.9.2",
+    ivy"com.outr::scribe:3.13.0",
+    ivy"io.get-coursier::coursier:2.1.8",
   )
 }


### PR DESCRIPTION
* com.lihaoyi::os-lib       0.9.1 -> 0.9.2
* com.outr::scribe          3.11.5 -> 3.13.0
* io.get-coursier::coursier 2.1.8 -> 2.1.8