### PR TITLE
Namespace environment variables with CHISEL_

### DIFF
--- a/firtool-resolver/src/Main.scala
+++ b/firtool-resolver/src/Main.scala
@@ -17,7 +17,7 @@ final case class FirtoolBinary(path: File, version: String)
 /** Resolve a firtool binary
   *
   * The basic algorithm is as follows
-  *   - Check for firtool on the FIRTOOL_PATH, note any version mismatch
+  *   - Check for firtool on the CHISEL_FIRTOOL_PATH, note any version mismatch
   *   - Check for firtool in resources, note any version mismtach
   *     - If found, check if already extracted, extract if not
   *   - If none of the above found, use coursier to fetch firtool and check resources again
@@ -66,7 +66,7 @@ object Resolve {
   private val VersionRegex = """^CIRCT firtool-(\S+)$""".r
 
   private def cacheDir: String = {
-    val path = sys.env.getOrElse("FIRTOOL_CACHE", ProjectDirectories.from("", groupId, artId).cacheDir)
+    val path = sys.env.getOrElse("CHISEL_FIRTOOL_CACHE", ProjectDirectories.from("", groupId, artId).cacheDir)
     new File(path).getAbsolutePath()
   }
 
@@ -78,19 +78,19 @@ object Resolve {
     def Recoverable(msg: String): Either[String, Either[String, FirtoolBinary]] = Right(Left(msg))
     def Unrecoverable(msg: String): Either[String, Either[String, FirtoolBinary]] = Left(msg)
 
-    logger.debug("Checking FIRTOOL_PATH for firtool")
+    logger.debug("Checking CHISEL_FIRTOOL_PATH for firtool")
 
     // TODO make this function more consistent between return and matching
-    val firtoolPathOpt = sys.env.get("FIRTOOL_PATH")
+    val firtoolPathOpt = sys.env.get("CHISEL_FIRTOOL_PATH")
     if (firtoolPathOpt.isEmpty) {
-      val msg = "FIRTOOL_PATH not set"
+      val msg = "CHISEL_FIRTOOL_PATH not set"
       logger.debug(msg)
       return Recoverable(msg)
     }
 
     val firtoolPath = os.Path(firtoolPathOpt.get, os.pwd)
     if (!os.exists(firtoolPath)) {
-      val msg = s"FIRTOOL_PATH ($firtoolPath) does not exist"
+      val msg = s"CHISEL_FIRTOOL_PATH ($firtoolPath) does not exist"
       logger.debug(msg)
       return Unrecoverable(msg)
     }
@@ -219,7 +219,7 @@ object Resolve {
 
   /** Lookup firtool binary
     *
-    * @param defaultVersion fallback version to fetch if not found in FIRTOOL_PATH nor on classpath
+    * @param defaultVersion fallback version to fetch if not found in CHISEL_FIRTOOL_PATH nor on classpath
     * @param verbose print verbose logging information
     * @return Either an error message or the firtool binary
     */

--- a/firtool-resolver/test/fetched.sh
+++ b/firtool-resolver/test/fetched.sh
@@ -8,8 +8,8 @@ cs launch --scala 2.13.11 \
   -v \
   $LLVM_FIRTOOL_VERSION
 )
-# CHECK: Checking FIRTOOL_PATH for firtool
-# CHECK: FIRTOOL_PATH not set
+# CHECK: Checking CHISEL_FIRTOOL_PATH for firtool
+# CHECK: CHISEL_FIRTOOL_PATH not set
 # CHECK: Checking resources for firtool
 # CHECK: firtool version not found in resources
 # CHECK: Attempting to fetch org.chipsalliance:llvm-firtool:[[LLVM_FIRTOOL_VERSION]]

--- a/firtool-resolver/test/firtool_cache.sh
+++ b/firtool-resolver/test/firtool_cache.sh
@@ -9,10 +9,10 @@ cs launch --scala 2.13.11 \
   -v \
   $LLVM_FIRTOOL_VERSION
 )
-# CHECK: Checking FIRTOOL_PATH for firtool
-# CHECK: FIRTOOL_PATH not set
+# CHECK: Checking CHISEL_FIRTOOL_PATH for firtool
+# CHECK: CHISEL_FIRTOOL_PATH not set
 # CHECK: Checking resources for firtool
 # CHECK: Firtool version [[LLVM_FIRTOOL_VERSION]] found in resources
-# CHECK: Copying firtool from resources to{{.*}}[[FIRTOOL_CACHE]]{{.}}[[LLVM_FIRTOOL_VERSION]]{{.}}bin{{.}}firtool
+# CHECK: Copying firtool from resources to{{.*}}[[CHISEL_FIRTOOL_CACHE]]{{.}}[[LLVM_FIRTOOL_VERSION]]{{.}}bin{{.}}firtool
 $FIRTOOL --version
 # CHECK: CIRCT firtool-[[FIRTOOL_VERSION]]

--- a/firtool-resolver/test/firtool_path.sh
+++ b/firtool-resolver/test/firtool_path.sh
@@ -9,7 +9,7 @@ cs launch --scala 2.13.11 \
   -- \
   $LLVM_FIRTOOL_VERSION
 )
-export FIRTOOL_PATH=$(dirname $FIRTOOL_BIN)
+export CHISEL_FIRTOOL_PATH=$(dirname $FIRTOOL_BIN)
 
 FIRTOOL=$(
 cs launch --scala 2.13.11 \
@@ -19,14 +19,14 @@ cs launch --scala 2.13.11 \
   -v \
   $LLVM_FIRTOOL_VERSION
 )
-# CHECK: Checking FIRTOOL_PATH for firtool
+# CHECK: Checking CHISEL_FIRTOOL_PATH for firtool
 # CHECK: Running: {{.+}}bin{{.}}firtool --version
-# CHECK-NOT: FIRTOOL_PATH not set
+# CHECK-NOT: CHISEL_FIRTOOL_PATH not set
 # CHECK-NOT: Checking resources for firtool
 $FIRTOOL --version
 # CHECK: CIRCT firtool-[[FIRTOOL_VERSION]]
 
-# We need to also check that if FIRTOOL_PATH is set, we return failure if something goes wrong
+# We need to also check that if CHISEL_FIRTOOL_PATH is set, we return failure if something goes wrong
 # rather than just going ahead and fetching the dfeault version
 mv $FIRTOOL_BIN ${FIRTOOL_BIN}_renamed
 
@@ -36,8 +36,8 @@ cs launch --scala 2.13.11 \
   -- \
   -v \
   $LLVM_FIRTOOL_VERSION
-# CHECK: Checking FIRTOOL_PATH for firtool
+# CHECK: Checking CHISEL_FIRTOOL_PATH for firtool
 # CHECK: Running: {{.+}}bin{{.}}firtool --version
 # CHECK: Cannot run program {{.+}}firtool
-# CHECK-NOT: FIRTOOL_PATH not set
+# CHECK-NOT: CHISEL_FIRTOOL_PATH not set
 # CHECK-NOT: Checking resources for firtool

--- a/firtool-resolver/test/on_classpath.sh
+++ b/firtool-resolver/test/on_classpath.sh
@@ -9,8 +9,8 @@ cs launch --scala 2.13.11 \
   -v \
   $LLVM_FIRTOOL_VERSION
 )
-# CHECK: Checking FIRTOOL_PATH for firtool
-# CHECK: FIRTOOL_PATH not set
+# CHECK: Checking CHISEL_FIRTOOL_PATH for firtool
+# CHECK: CHISEL_FIRTOOL_PATH not set
 # CHECK: Checking resources for firtool
 # CHECK: Firtool version [[LLVM_FIRTOOL_VERSION]] found in resources
 $FIRTOOL --version

--- a/firtool-resolver/test/run_tests.sh
+++ b/firtool-resolver/test/run_tests.sh
@@ -34,4 +34,4 @@ else
   filecheck_cache=$cache
 fi
 rm -rf $cache
-FIRTOOL_CACHE=$cache $THIS_DIR/firtool_cache.sh 2>&1 | FileCheck -DLLVM_FIRTOOL_VERSION="$LLVM_FIRTOOL_VERSION" -DFIRTOOL_VERSION="$FIRTOOL_VERSION" -DFIRTOOL_CACHE="$filecheck_cache" $THIS_DIR/firtool_cache.sh
+CHISEL_FIRTOOL_CACHE=$cache $THIS_DIR/firtool_cache.sh 2>&1 | FileCheck -DLLVM_FIRTOOL_VERSION="$LLVM_FIRTOOL_VERSION" -DFIRTOOL_VERSION="$FIRTOOL_VERSION" -DCHISEL_FIRTOOL_CACHE="$filecheck_cache" $THIS_DIR/firtool_cache.sh


### PR DESCRIPTION
This is needed for Chisel 6.0 as it's better to namespace your environment variables.

* Rename FIRTOOL_PATH to CHISEL_FIRTOOL_PATH
* Rename FIRTOOL_CACHE to CHISEL_FIRTOOL_CACHE

This change is obviously not ideal from the perspective of this being an independent project from Chisel, but it's pragmatic. Longer term, the name of these variables should be customizable by the user of this library (similarly to how this library should/could be independent of firtool).