### PR TITLE
Remove dependency on os-lib

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -244,7 +244,6 @@ object `firtool-resolver` extends ScalaModule with ChipsAlliancePublishModule {
 
   def ivyDeps = Agg(
     ivy"dev.dirs:directories:26",
-    ivy"com.lihaoyi::os-lib:0.9.2",
     ivy"com.outr::scribe:3.13.0",
     ivy"io.get-coursier::coursier:2.1.8",
   )


### PR DESCRIPTION
It is a binary compatibility concern (via transitive dependency on geny). This would be okay since we can create a fat jar and shade dependencies, but trying to shade package os.** seems to cause issues with loading system property "os.name" which we need to use the correct binary for the user's system.

We aren't gaining much by using it and it causes problems, so remove the dependency.