### PR TITLE
Remove dependency on scribe, use minimal logging shim

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -284,7 +284,6 @@ object `firtool-resolver` extends ScalaModule with ChipsAlliancePublishModule { 
     // getting System property os.name
     def ivyDeps = Agg(
       ivy"dev.dirs:directories:26",
-      ivy"com.outr::scribe:3.13.0",
       ivy"io.get-coursier::coursier:2.1.8",
     )
 
@@ -294,7 +293,6 @@ object `firtool-resolver` extends ScalaModule with ChipsAlliancePublishModule { 
       // Remove Scala jars.
       // This removes scala-library, scala-collection-compat, and scala-xml.
       val regex = """.*/scala[^\/]*\.jar""".r
-      all.filter(path => regex.matches(path.toString)).foreach(println)
       all.filterNot(path => regex.matches(path.toString))
     }
 
@@ -305,11 +303,7 @@ object `firtool-resolver` extends ScalaModule with ChipsAlliancePublishModule { 
     // It would be nice if this could be derived from dependencies.
     def packagesToShade = Seq(
       "dev.dirs",
-      "scribe",
       "coursier",
-      "perfolation",
-      "sourcecode",
-      "moduload",
       "com.github.plokhotnyuk",
       "concurrentrefhashmap",
       "org.codehaus",

--- a/firtool-resolver/src/Logger.scala
+++ b/firtool-resolver/src/Logger.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firtoolresolver
+
+/** Minimal Logger API
+  *
+  * Used by firtoolresolver for its own purposes, easy for downstream projects to shim
+  */
+trait Logger {
+  def error(msg: String): Unit
+  def warn(msg: String): Unit
+  def info(msg: String): Unit
+  def debug(msg: String): Unit
+  def trace(msg: String): Unit
+}
+object Logger {
+  /** Print warning level and above to stderr */
+  def warn: Logger = new Logger {
+    def error(msg: String): Unit = Console.err.println(msg)
+    def warn(msg: String): Unit = Console.err.println(msg)
+    def info(msg: String): Unit = ()
+    def debug(msg: String): Unit = ()
+    def trace(msg: String): Unit = ()
+  }
+  /** Print debug level and above to stderr */
+  def debug: Logger = new Logger {
+    def error(msg: String): Unit = Console.err.println(msg)
+    def warn(msg: String): Unit = Console.err.println(msg)
+    def info(msg: String): Unit = Console.err.println(msg)
+    def debug(msg: String): Unit = Console.err.println(msg)
+    def trace(msg: String): Unit = ()
+  }
+}

--- a/firtool-resolver/src/Main.scala
+++ b/firtool-resolver/src/Main.scala
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: Apache-2.0
 
 package firtoolresolver
@@ -12,7 +11,6 @@ import java.net.URLClassLoader
 import scala.sys.process._
 
 import dev.dirs.{BaseDirectories, ProjectDirectories, UserDirectories}
-import scribe.Logger
 import coursier._
 import coursier.core.Extension
 
@@ -233,11 +231,7 @@ object Resolve {
     * @return Either an error message or the firtool binary
     */
   def apply(defaultVersion: String, verbose: Boolean = false): Either[String, FirtoolBinary] = {
-    val level = if (verbose) scribe.Level.Debug else scribe.Level.Warn
-    val logger =
-      Logger("FirtoolResolver")
-        .withHandler(formatter = scribe.format.Formatter.enhanced)
-        .withMinimumLevel(level)
+    val logger = if (verbose) Logger.debug else Logger.warn
     apply(logger, defaultVersion)
   }
 


### PR DESCRIPTION
Downstream users (eg. Chisel) can still use scribe or whatever logging library they choose.

It was also broken after doing the assembly change since we were shading our use of scribe.