### PR TITLE
Use native image of FindNewReleases in CD

### DIFF
--- a/.github/scripts/FindNewReleases.scala
+++ b/.github/scripts/FindNewReleases.scala
@@ -3,6 +3,7 @@
 //> using dep "io.get-coursier::coursier:2.1.10"
 //> using dep "com.lihaoyi::upickle:3.3.1"
 //> using options "-unchecked", "-deprecation", "-feature", "-Xcheckinit", "-Xfatal-warnings", "-Ywarn-dead-code", "-Ywarn-unused"
+//> using packaging.graalvmArgs "--enable-url-protocols=https"
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/.github/workflows/cd-llvm-firtool.yml
+++ b/.github/workflows/cd-llvm-firtool.yml
@@ -13,16 +13,25 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Java
-        run: echo "JAVA_HOME=${JAVA_HOME_17_X64}" >> "$GITHUB_ENV"
-      - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1
+      - name: Cache FindNewReleases
+        uses: actions/cache@v3
+        id: docache
         with:
-          jvm: '' # Deliberately empty to avoid downloading JVM.
+          path: FindNewReleases
+          key: ${{ runner.os }}-FindNewReleases-${{ hashFiles('.github/scripts/FindNewReleases.scala') }}
+      # Dont bother caching Scala build, we rarely need to rebuild FindNewReleases
+      - name: Setup Scala
+        uses: VirtusLab/scala-cli-setup@v1
+        if: steps.docache.outputs.cache-hit != 'true'
+        with:
+          jvm: 'graalvm-community:21.0.2'
+      - name: Compile FindNewReleases
+        if: steps.docache.outputs.cache-hit != 'true'
+        run: |
+          scala-cli --power package --graal --graalvm-java-version 21 --graalvm-version 21.0.2 --force -o FindNewReleases .github/scripts/FindNewReleases.scala
       - id: detect-versions
         run: |
-          # --server=false avoids an hang.
-          versions=$(scala-cli --server=false .github/scripts/FindNewReleases.scala)
+          versions=$(./FindNewReleases)
           echo "versions=$versions" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reduces the runtime of `Detect New Versions` from 15-25 seconds to 6-12 seconds. It also shrinks the cache size since it only now caches the actual native binary.