### PR TITLE
[ci] Use macos-13 runner, not macos-12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       matrix:
         scala-version: ["2.13", "2.12"]
-        runner: ["ubuntu-20.04", "macos-12", "windows-2019"]
+        runner: ["ubuntu-20.04", "macos-13", "windows-2019"]
         include:
           - runner: ubuntu-20.04
             os: linux
             arch: x64
             ext: ""
-          - runner: macos-12
+          - runner: macos-13
             os: macos
             arch: x64
             ext: ""


### PR DESCRIPTION
Change the macOS runner from 12 to 13 as 12 was deprecated and is no longer supported.