### PR TITLE
Update actions versions and macos and windows runners

### DIFF
--- a/.github/workflows/cd-llvm-firtool.yml
+++ b/.github/workflows/cd-llvm-firtool.yml
@@ -12,9 +12,9 @@ jobs:
     name: Detect New Versions
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache FindNewReleases
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: docache
         with:
           path: FindNewReleases

--- a/.github/workflows/publish-firtool-resolver.yml
+++ b/.github/workflows/publish-firtool-resolver.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v2
         with:
           jvm: adopt:11
       - name: Import GPG key
-        # This is crazy-max/ghaction-import-gpg@v6, using commit for security reasons
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef
+        # This is crazy-max/ghaction-import-gpg@v6.3.0, using commit for security reasons
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/publish-firtool-resolver.yml
+++ b/.github/workflows/publish-firtool-resolver.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Scala and Coursier
         uses: coursier/setup-action@v2
         with:
-          jvm: adopt:11
+          jvm: temurin:17
       - name: Import GPG key
         # This is crazy-max/ghaction-import-gpg@v6.3.0, using commit for security reasons
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec

--- a/.github/workflows/publish-llvm-firtool.yml
+++ b/.github/workflows/publish-llvm-firtool.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Scala and Coursier
         uses: coursier/setup-action@v2
         with:
-          jvm: adopt:11
+          jvm: temurin:17
       - name: Check if already published
         if: ${{ ! inputs.snapshot }}
         # TODO skip if snapshot

--- a/.github/workflows/publish-llvm-firtool.yml
+++ b/.github/workflows/publish-llvm-firtool.yml
@@ -41,9 +41,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v2
         with:
           jvm: adopt:11
       - name: Check if already published
@@ -67,8 +67,8 @@ jobs:
           echo "LLVM_FIRTOOL_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
           echo "LLVM_FIRTOOL_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
       - name: Import GPG key
-        # This is crazy-max/ghaction-import-gpg@v6, using commit for security reasons
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef
+        # This is crazy-max/ghaction-import-gpg@v6.3.0, using commit for security reasons
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Scala and Coursier
         uses: coursier/setup-action@v2
         with:
-          jvm: adopt:11
+          jvm: temurin:17
       - name: Set versions
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,24 +19,24 @@ jobs:
     strategy:
       matrix:
         scala-version: ["2.13", "2.12"]
-        runner: ["ubuntu-24.04", "macos-13", "windows-2022"]
+        runner: ["ubuntu-24.04", "macos-15", "windows-2025"]
         include:
           - runner: ubuntu-24.04
             os: linux
             arch: x64
             ext: ""
-          - runner: macos-13
+          - runner: macos-15
             os: macos
-            arch: x64
+            arch: arm64
             ext: ""
-          - runner: windows-2022
+          - runner: windows-2025
             os: windows
             arch: x64
             ext: ".exe"
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install wget (Windows)
         if: matrix.os == 'windows'
         run: choco install wget
@@ -53,7 +53,7 @@ jobs:
           ./FileCheck --version
           cd ..
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v2
         with:
           jvm: adopt:11
       - name: Set versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             ext: ""
           - runner: macos-15
             os: macos
-            arch: arm64
+            arch: x64 # Technically it's x64 but we rely on Rosetta for the time being.
             ext: ""
           - runner: windows-2025
             os: windows


### PR DESCRIPTION
This also updates the JVM we're using from adopt:11 to temurin:17. Note that we use `-release:8` for firtool-resolver so published artifacts maintain support for Java 8.