### PR TITLE
Add support for aarch64 macos firtool binaries

### DIFF
--- a/.github/scripts/FindNewReleases.scala
+++ b/.github/scripts/FindNewReleases.scala
@@ -24,7 +24,10 @@ object Releases {
 
   // NOTE: These files must be kept in sync with the artifacts downloaded in build.sc
   val expectedAritfacts = Seq(
-    "firrtl-bin-linux-x64.tar.gz", "firrtl-bin-macos-x64.tar.gz", "firrtl-bin-windows-x64.zip"
+    "firrtl-bin-linux-x64.tar.gz",
+    "firrtl-bin-macos-x64.tar.gz",
+    "firrtl-bin-macos-arm64.tar.gz",
+    "firrtl-bin-windows-x64.zip"
   )
 
   val httpClient: Client[IO] = JavaNetClientBuilder[IO].create

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/test.yml
     with:
-      version: '1.58.0'
+      version: '1.144.0'
       snapshot: 'true'
 
   publish:

--- a/build.mill
+++ b/build.mill
@@ -13,6 +13,11 @@ import com.lumidion.sonatype.central.client.core.{PublishingType, SonatypeCreden
 
 case class Platform(os: String, arch: String) {
   override def toString: String = s"$os-$arch"
+  // CIRCT release artifacts use "arm64" but FNDDS uses "aarch64"
+  def circtArtifactName: String = (os, arch) match {
+    case ("macos", "aarch64") => "macos-arm64"
+    case _ => this.toString
+  }
 }
 object Platform {
   // Needed to use Platform's in T[_] results
@@ -78,7 +83,7 @@ trait ChipsAlliancePublishModule extends SonatypeCentralPublishModule {
 }
 
 // Must run mill with -i because it uses environment variables:
-// LLVM_FIRTOOL_VERSION - (eg. 1.58.0)
+// LLVM_FIRTOOL_VERSION - (eg. 1.144.0)
 // LLVM_FIRTOOL_PRERELEASE - 0 means real release (non-SNAPSHOT), otherwise is -SNAPSHOT
 // Maven appears to have an API for resolving classifiers at fetch time,
 // but it's not supported by Coursier: https://github.com/coursier/coursier/issues/2016
@@ -100,6 +105,7 @@ object `llvm-firtool` extends JavaModule with ChipsAlliancePublishModule {
 
   val platforms = Seq[Platform](
     Platform("macos", "x64"),
+    Platform("macos", "aarch64"),
     Platform("linux", "x64"),
     Platform("windows", "x64")
   )
@@ -122,9 +128,9 @@ object `llvm-firtool` extends JavaModule with ChipsAlliancePublishModule {
   def tarballs = T {
     platforms.map { platform =>
       val tarballName = if (platform.os == "windows") {
-        s"firrtl-bin-$platform.zip"
+        s"firrtl-bin-${platform.circtArtifactName}.zip"
       } else {
-        s"firrtl-bin-$platform.tar.gz"
+        s"firrtl-bin-${platform.circtArtifactName}.tar.gz"
       }
       val archiveUrl = s"$releaseUrl/$tarballName"
       val file = T.dest / tarballName
@@ -134,9 +140,7 @@ object `llvm-firtool` extends JavaModule with ChipsAlliancePublishModule {
   }
 
   def extractedDirs = T {
-    val tarballLookup = tarballs().toMap
-    platforms.map { platform =>
-      val tarball = tarballLookup(platform)
+    tarballs().map { case (platform, tarball) =>
       val dir = T.dest / platform.toString
       os.makeDir.all(dir)
       // Windows uses .zip

--- a/firtool-resolver/src/Main.scala
+++ b/firtool-resolver/src/Main.scala
@@ -49,20 +49,16 @@ object Resolve {
   // Important constants
   private def groupId = "org.chipsalliance"
   private def artId = "llvm-firtool"
-  // Use x64 for Apple Silicon
-  private def appleSiliconFixup(logger: Logger, os: String, arch: String): String = {
-    if (os == "macos" && arch == "aarch64") {
-      logger.debug("Using x64 architecture for Apple silicon")
-      "x64"
-    } else {
-      arch
-    }
+  // Returns a fallback platform when a platform's native artifacts may not be available.
+  // macOS aarch64 falls back to x64 (via Rosetta) for versions that lack native arm64 artifacts.
+  private def fallbackPlatform(platform: String): Option[String] = platform match {
+    case "macos-aarch64" => Some("macos-x64")
+    case _ => None
   }
   private def determinePlatform(logger: Logger): Either[String, String] =
     for {
       os <- operatingSystem
-      _arch <- architecture
-      arch = appleSiliconFixup(logger, os, _arch)
+      arch <- architecture
     } yield s"$os-$arch"
   private def binaryName = "firtool"
   private val VersionRegex = """^CIRCT firtool-(\S+)$""".r
@@ -145,10 +141,10 @@ object Resolve {
       logger.debug(platform.merge)
       return Left(platform.merge) // Help out the type system
     }
+    val primaryPlatform = platform.toOption.get
     val resourceLoader = classloader.getOrElse(this.getClass.getClassLoader)
 
     val baseDir = s"$groupId/$artId"
-    val artDir = s"$baseDir/${platform.toOption.get}" // checked above
     val versionFile = resourceLoader.getResource(s"$baseDir/project.version")
     val versionOpt = Try(Source.fromURL(versionFile).mkString).toOption
     if (versionOpt.isEmpty) {
@@ -159,6 +155,21 @@ object Resolve {
 
     val version = versionOpt.get
     logger.debug(s"Firtool version $version found in resources")
+
+    // Try primary platform then fallback (e.g. macos-aarch64 → macos-x64) if no resource found
+    val platformsToTry = Seq(primaryPlatform) ++ fallbackPlatform(primaryPlatform)
+    val effectivePlatform = platformsToTry.find { p =>
+      resourceLoader.getResource(s"$baseDir/$p/bin/firtool") != null
+    }
+    if (effectivePlatform.isEmpty) {
+      val msg = s"firtool binary not found in resources for platforms: ${platformsToTry.mkString(", ")}"
+      logger.debug(msg)
+      return Left(msg)
+    }
+    if (effectivePlatform.get != primaryPlatform) {
+      logger.debug(s"Falling back to ${effectivePlatform.get} resources (no $primaryPlatform resources found)")
+    }
+    val artDir = s"$baseDir/${effectivePlatform.get}"
 
     val destBin = firtoolBin(version)
     val destFile: File = destBin.toFile
@@ -214,34 +225,48 @@ object Resolve {
           return Left(msg)
         case Right(name) => name
       }
-    // See coursier.parse.DependencyParser to understand how the classifier is added via Publication
-    val org = Organization(groupId)
-    val module = Module(org, ModuleName(s"$artId"), Map())
-    val dep =
-      Dependency(module, defaultVersion)
-        .withPublication("", Type.empty, Extension.empty, Classifier(platform))
-    // One would think there'd be a built-in pretty print like this but there isn't
-    //   (coursier.util.Print doesn't include the classifier)
-    logger.debug(s"Attempting to fetch ${dep.module}:${dep.version},clasifier=${platform}")
 
-    val resolution = Try {
-      coursier.Fetch()
-      .addDependencies(dep)
-      .run()
+    // Try fetching for a specific platform classifier; returns Left on any failure.
+    def tryFetch(p: String): Either[String, FirtoolBinary] = {
+      // See coursier.parse.DependencyParser to understand how the classifier is added via Publication
+      val org = Organization(groupId)
+      val module = Module(org, ModuleName(s"$artId"), Map())
+      val dep =
+        Dependency(module, defaultVersion)
+          .withPublication("", Type.empty, Extension.empty, Classifier(p))
+      // One would think there'd be a built-in pretty print like this but there isn't
+      //   (coursier.util.Print doesn't include the classifier)
+      logger.debug(s"Attempting to fetch ${dep.module}:${dep.version},classifier=${p}")
+
+      val resolution = Try {
+        coursier.Fetch()
+          .addDependencies(dep)
+          .run()
+      }
+      if (resolution.isFailure) {
+        val msg = resolution.failed.get.toString + "\n" // Coursier's message is already pretty good
+        logger.debug(msg)
+        return Left(msg)
+      }
+      // Head here is dangerous, without the classifier, multiple jars are fetched
+      val jar = resolution.get.head
+      logger.debug(s"Successfully fetched $jar")
+
+      logger.debug(s"Loading $jar to search its resources")
+      val classloader = new URLClassLoader(Array(jar.toURI.toURL))
+      checkResources(Some(classloader), logger)
     }
-    if (resolution.isFailure) {
-      val msg = resolution.failed.get.toString + "\n" // Coursier's message is already pretty good
-      logger.debug(msg)
-      return Left(msg)
+
+    tryFetch(platform) match {
+      case right @ Right(_) => right
+      case left @ Left(_) =>
+        fallbackPlatform(platform) match {
+          case Some(fallback) =>
+            logger.debug(s"Falling back to platform $fallback")
+            tryFetch(fallback)
+          case None => left
+        }
     }
-    // Head here is dangerous, without the classifier, multiple jars are fetched
-    val jar = resolution.get.head
-    logger.debug(s"Successfully fetched $jar")
-
-
-    logger.debug(s"Loading $jar to search its resources")
-    val classloader = new URLClassLoader(Array(jar.toURI.toURL))
-    checkResources(Some(classloader), logger)
   }
 
   /** Lookup firtool binary


### PR DESCRIPTION
They will now be required by FindNewReleases for CD, but the firtool-resolver logic will still support falling back to x64 on macos aarch64 because users could use older versions of `llvm-firtool` that did not have the macos aarch64 binary available.