### PR TITLE
Bump Github Actions versions, uses hashes

### DIFF
--- a/.github/workflows/cd-llvm-firtool.yml
+++ b/.github/workflows/cd-llvm-firtool.yml
@@ -21,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-FindNewReleases-${{ hashFiles('.github/scripts/FindNewReleases.scala') }}
       # Dont bother caching Scala build, we rarely need to rebuild FindNewReleases
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@v1
+        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
         if: steps.docache.outputs.cache-hit != 'true'
         with:
           jvm: 'graalvm-community:21.0.2'

--- a/.github/workflows/publish-firtool-resolver.yml
+++ b/.github/workflows/publish-firtool-resolver.yml
@@ -15,12 +15,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: temurin:17
       - name: Import GPG key
-        # This is crazy-max/ghaction-import-gpg@v6.3.0, using commit for security reasons
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/publish-llvm-firtool.yml
+++ b/.github/workflows/publish-llvm-firtool.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: temurin:17
       - name: Check if already published
@@ -67,8 +67,7 @@ jobs:
           echo "LLVM_FIRTOOL_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
           echo "LLVM_FIRTOOL_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
       - name: Import GPG key
-        # This is crazy-max/ghaction-import-gpg@v6.3.0, using commit for security reasons
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.PGP_SECRET }}
           passphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           ./FileCheck --version
           cd ..
       - name: Install Scala and Coursier
-        uses: coursier/setup-action@v2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: temurin:17
       - name: Set versions


### PR DESCRIPTION
- VirtusLab/scala-cli-setup: v1 => v1.12.5
- coursier/setup-action: v2 => v3.0.0
- crazy-max/ghaction-import-gpg: v6.3.0 => v7.0.0